### PR TITLE
Add rule for checking unused param vars

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -7,5 +7,6 @@
   "import/no-unresolved": ["error"],
   "max-len": ["error", 127],
   "require-jsdoc": ["off"],
-  "space-infix-ops": ["error", {"int32Hint": false}]
+  "space-infix-ops": ["error", {"int32Hint": false}],
+  "no-unused-vars": ["error", {"args": "all", "argsIgnorePattern": "^_"}]
 }


### PR DESCRIPTION
Exceptions are vars that has names starting with `_`