### PR TITLE
Add configuration for import/no-useless-path-segments

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -5,6 +5,7 @@
   "indent": ["error", 2, {"MemberExpression": 1}],
   "import/first": ["error"],
   "import/no-unresolved": ["error"],
+  "import/no-useless-path-segments": ["error"],
   "max-len": ["error", 127],
   "require-jsdoc": ["off"],
   "space-infix-ops": ["error", {"int32Hint": false}]


### PR DESCRIPTION
This plugins detects unnecessary path segments in imports (like './/some', '../some/foo' instead of './foo')

https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-useless-path-segments.md

