### PR TITLE
Add configuration for import/no-extraneous-dependencies

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -5,6 +5,7 @@
   "indent": ["error", 2, {"MemberExpression": 1}],
   "import/first": ["error"],
   "import/no-unresolved": ["error"],
+  "import/no-extraneous-dependencies": ["error"],
   "max-len": ["error", 127],
   "require-jsdoc": ["off"],
   "space-infix-ops": ["error", {"int32Hint": false}]


### PR DESCRIPTION
This rules detects when we import a package that is not declared in package.json. For instance in lib-ui we import prop-types that is not declared and in api-profile we used to import uuid.

https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md